### PR TITLE
Fix duplicate listener leak in toast hook

### DIFF
--- a/components/ui/use-toast.ts
+++ b/components/ui/use-toast.ts
@@ -177,7 +177,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- avoid re-registering `useToast` listener on every toast state change

## Testing
- `npm run type-check` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6844599d0f20832aab37690561b4ea7f